### PR TITLE
Add onDrawerChanged event handler

### DIFF
--- a/lib/src/helper/utils.dart
+++ b/lib/src/helper/utils.dart
@@ -2,6 +2,10 @@ import 'dart:ui';
 
 import 'package:flutter_slider_drawer/flutter_slider_drawer.dart';
 
+/// Signature for the callback that's called when a [DrawerController] is
+/// opened or closed.
+typedef DrawerCallback = void Function(bool isOpened);
+
 class Utils {
   ///
   /// This method get Offset base on [sliderOpen] type

--- a/lib/src/slider.dart
+++ b/lib/src/slider.dart
@@ -153,9 +153,9 @@ class SliderDrawerState extends State<SliderDrawer>
         vsync: this, duration: Duration(milliseconds: widget.animationDuration))
       ..addStatusListener((status) {
         if (status == AnimationStatus.completed) {
-          widget.onDrawerChanged!(true);
+          widget.onDrawerChanged?.call(true);
         } else if (status == AnimationStatus.dismissed) {
-          widget.onDrawerChanged!(false);
+          widget.onDrawerChanged?.call(false);
         }
       });
 

--- a/lib/src/slider.dart
+++ b/lib/src/slider.dart
@@ -92,20 +92,24 @@ class SliderDrawer extends StatefulWidget {
   ///
   final bool isCupertino;
 
-  const SliderDrawer(
-      {Key? key,
-      required this.slider,
-      required this.child,
-      this.isDraggable = true,
-      this.animationDuration = 400,
-      this.sliderOpenSize = 265,
-      this.splashColor = const Color(0xffffff),
-      this.sliderCloseSize = 0,
-      this.slideDirection = SlideDirection.LEFT_TO_RIGHT,
-      this.sliderBoxShadow,
-      this.appBar = const SliderAppBar(),
-      this.isCupertino = false})
-      : super(key: key);
+  /// Optional callback that is called when the [Scaffold.drawer] is opened or closed.
+  final DrawerCallback? onDrawerChanged;
+
+  const SliderDrawer({
+    Key? key,
+    required this.slider,
+    required this.child,
+    this.isDraggable = true,
+    this.animationDuration = 400,
+    this.sliderOpenSize = 265,
+    this.splashColor = const Color(0xffffff),
+    this.sliderCloseSize = 0,
+    this.slideDirection = SlideDirection.LEFT_TO_RIGHT,
+    this.sliderBoxShadow,
+    this.appBar = const SliderAppBar(),
+    this.isCupertino = false,
+    this.onDrawerChanged,
+  }) : super(key: key);
 
   @override
   SliderDrawerState createState() => SliderDrawerState();
@@ -146,8 +150,14 @@ class SliderDrawerState extends State<SliderDrawer>
     super.initState();
 
     _animationDrawerController = AnimationController(
-        vsync: this,
-        duration: Duration(milliseconds: widget.animationDuration));
+        vsync: this, duration: Duration(milliseconds: widget.animationDuration))
+      ..addStatusListener((status) {
+        if (status == AnimationStatus.completed) {
+          widget.onDrawerChanged!(true);
+        } else if (status == AnimationStatus.dismissed) {
+          widget.onDrawerChanged!(false);
+        }
+      });
 
     _animation =
         Tween<double>(begin: widget.sliderCloseSize, end: widget.sliderOpenSize)


### PR DESCRIPTION
Changes: Adding the `onDrawerChanged` event handler for monitoring changes in the Drawer status.

Motivation: Hello, and thank you for creating this wonderful library. I am interested in using it and would like to capture events when the Drawer status changes. Therefore, I have already tested it and can confirm it works on iOS 18.0.

Usage: By including the argument

```
onDrawerChanged: (opened) {
  print(opened);
}
```
you can monitor the Drawer open/close events.